### PR TITLE
fix(RNNetPrinterModule): ios connectPrinter function arguments nonnul…

### DIFF
--- a/ios/RNNetPrinter.m
+++ b/ios/RNNetPrinter.m
@@ -131,7 +131,7 @@ RCT_EXPORT_METHOD(getDeviceList:(RCTResponseSenderBlock)successCallback
 }
 
 RCT_EXPORT_METHOD(connectPrinter:(NSString *)host
-                  withPort:(NSNumber *)port
+                  withPort:(nonnull NSNumber *)port
                   success:(RCTResponseSenderBlock)successCallback
                   fail:(RCTResponseSenderBlock)errorCallback) {
     @try {


### PR DESCRIPTION
## Summary

On version `1.1.5` we have some small issue with `NetPrinter.connectPrinter` function on `ios`

Error: `Argument 1 (NSNumber) of RNNetPrinter.connectPrinter has unspecified nullability but React requires that all NSNumber arguments are explicitly marked as ``nonnull`` to ensure compatibility with Android.`

![Simulator Screen Shot - iPhone 11 - 2021-05-25 at 19 58 26](https://user-images.githubusercontent.com/26211549/119506225-eaaf4b00-bd97-11eb-8466-fe6d82709a5a.png)


## Environment

```
System:
    OS: macOS Big Sur 11.1
    CPU: (8) x64 Intel(R) Core(TM) i7-6920HQ CPU @ 2.90GHz
Binaries:
    node: v12.22.1
    npm: 6.14.12
    watchman: 4.9.0
SDKs:
    iOS SDK:
      Platforms: iOS 14.4
IDEs:
    Xcode: 12.4 (12D4e)
npmPackages:
    react: 16.13.1
    react-native: 0.63.4
    react-native-thermal-receipt-printer: 1.1.5