### PR TITLE
Handled nonnull arguments requirement from react native to maintain android compatibility 

### DIFF
--- a/ios/RNNetPrinter.m
+++ b/ios/RNNetPrinter.m
@@ -133,7 +133,7 @@ RCT_EXPORT_METHOD(getDeviceList:(RCTResponseSenderBlock)successCallback
 }
 
 RCT_EXPORT_METHOD(connectPrinter:(NSString *)host
-                  withPort:(NSNumber *)port
+                  withPort:(nonnull NSNumber *)port
                   success:(RCTResponseSenderBlock)successCallback
                   fail:(RCTResponseSenderBlock)errorCallback) {
     @try {


### PR DESCRIPTION
## Summary

I was facing follow error from react native:

```
Argument 1 (NSNumber) of RNNetPrinter.connectPrinter has unspecified nullability but React requires that all NSNumber arguments are explicitly marked as `nonnull` to ensure compatibility with Android.

RCTLogArgumentError(RCTModuleMethod*, unsigned long, objc_object*, char const*)
    RCTModuleMethod.mm:67
-[RCTModuleMethod processMethodSignature]
-[RCTModuleMethod invokeWithBridge:module:arguments:]
facebook::react::invokeInner(RCTBridge*, RCTModuleData*, unsigned int, folly::dynamic const&, int, (anonymous namespace)::SchedulingContext)
facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_0::operator()() const
invocation function for block in facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)
_dispatch_call_block_and_release
_dispatch_client_callout
_dispatch_main_queue_drain
_dispatch_main_queue_callback_4CF
__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
__CFRunLoopRun
CFRunLoopRunSpecific
GSEventRunModal
-[UIApplication _run]
UIApplicationMain
main
start_sim
0x0
0x0
```

## Changelog
-Added nonnull attribute to the port argument in NetPrinter.connectPrinter function 

