### PR TITLE
Fixed WARN new NativeEventEmitter()

### DIFF
--- a/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
@@ -84,6 +84,16 @@ public class RNBLEPrinterModule extends ReactContextBaseJavaModule implements RN
         adapter.selectDevice(BLEPrinterDeviceId.valueOf(innerAddress), successCallback, errorCallback);
     }
 
+     // Required for EventEmitter Calls.
+    @ReactMethod
+    public void addListener(String eventName) {
+    }
+
+    // Required for EventEmitter Calls.
+    @ReactMethod
+    public void removeListeners(Integer count) {
+    }
+
     @Override
     public String getName() {
         return "RNBLEPrinter";


### PR DESCRIPTION
Fixed WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
